### PR TITLE
Feat: 최고 점수 기록 기능 구현, UI 반영 (#2)

### DIFF
--- a/Tile2048/Features/BoardFeature.swift
+++ b/Tile2048/Features/BoardFeature.swift
@@ -14,6 +14,7 @@ struct BoardFeature {
     struct State: Equatable {
         var board: Board
         var score: Int = 0
+        var high: Int = 0
     }
 
     enum Action {
@@ -49,6 +50,7 @@ struct BoardFeature {
                 return .none
 
             case .onAppear:
+                state.high = HighScore.load()
                 let empties = BoardLogic.emptyPositions(state.board)
                 if empties.count == state.board.size * state.board.size {
                     return .send(.addRandomTile)
@@ -56,6 +58,8 @@ struct BoardFeature {
                 return .none
 
             case .resetGame:
+                HighScore.updateIfHigher(state.score)
+                state.high = HighScore.load()
                 state.board = Board(size: state.board.size)
                 state.score = 0
                 return .send(.addRandomTile)
@@ -67,6 +71,6 @@ struct BoardFeature {
 extension BoardFeature.State {
     static let mock = BoardFeature.State(
         board: Board(size: 4),
-        score: 1234
+        score: 0
     )
 }

--- a/Tile2048/Utils/HighScore.swift
+++ b/Tile2048/Utils/HighScore.swift
@@ -1,0 +1,27 @@
+//
+//  HighScore.swift
+//  Tile2048
+//
+//  Created by Assistant on 10/22/25.
+//
+
+import Foundation
+
+enum HighScore {
+    static func load() -> Int {
+        UserDefaults.standard.integer(forKey: Constants.key)
+    }
+
+    static func updateIfHigher(_ newScore: Int) {
+        let current = load()
+        if newScore > current {
+            UserDefaults.standard.set(newScore, forKey: Constants.key)
+        }
+    }
+}
+
+extension HighScore {
+    fileprivate enum Constants {
+        static let key = "high_score_key"
+    }
+}

--- a/Tile2048/Views/BoardView.swift
+++ b/Tile2048/Views/BoardView.swift
@@ -30,6 +30,7 @@ struct BoardView: View {
             title
             Spacer()
             score
+            best
         }
     }
 
@@ -46,6 +47,22 @@ struct BoardView: View {
                 .foregroundColor(.primary)
 
             Text("\(store.score)")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundColor(.primary)
+                .minimumScaleFactor(0.5)
+        }
+        .frame(width: 90, height: 60)
+        .background(Color.gray.opacity(0.3))
+        .cornerRadius(8)
+    }
+
+    private var best: some View {
+        VStack(spacing: 4) {
+            Text("BEST")
+                .font(.caption)
+                .foregroundColor(.primary)
+
+            Text("\(store.high)")
                 .font(.system(size: 22, weight: .semibold))
                 .foregroundColor(.primary)
                 .minimumScaleFactor(0.5)


### PR DESCRIPTION
## 📌 Related Issue
> #2
## 🚀 Description
> 플레이어 최고 점수를 기록하고, 앱 재시작 후에도 정보를 불러올 수 있도록 구현
## 📸 Screenshot
<img width="314" height="644" alt="스크린샷 2025-10-22 오후 5 55 50" src="https://github.com/user-attachments/assets/24b3047f-bca4-4b27-9df7-ac5ae8791846" />

## 📢 Notes
> UserDefaults를 활용하여 구현하였습니다.